### PR TITLE
Update AndroidAfterPrepare.js

### DIFF
--- a/hooks/AndroidAfterPrepare.js
+++ b/hooks/AndroidAfterPrepare.js
@@ -1,6 +1,7 @@
+var fs = require( "fs" );
+
 module.exports = function(ctx) {
-    var fs = ctx.requireCordovaModule( "fs" ),
-        path = ctx.requireCordovaModule( "path" ),
+    var path = ctx.requireCordovaModule( "path" ),
         xml = ctx.requireCordovaModule( "cordova-common" ).xmlHelpers,
         et = ctx.requireCordovaModule( "elementtree" );
 


### PR DESCRIPTION
Change due to a Build Error. 

CordovaError: Using "requireCordovaModule" to load non-cordova module "fs" is not supported. Instead, add this module to your dependencies and use regular "require" to load it.